### PR TITLE
Fix alignment in buttons login and register and fix image size of pho…

### DIFF
--- a/stubs/v4/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/v4/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -28,8 +28,12 @@
                     <img :src="photoPreview" class="rounded-circle" width="80px" height="80px">
                 </div>
 
-                <jet-secondary-button class="mt-2" type="button" @click.native.prevent="selectNewPhoto">
+                <jet-secondary-button class="mt-2 mr-2" type="button" @click.native.prevent="selectNewPhoto">
                     Select A New Photo
+                </jet-secondary-button>
+
+				<jet-secondary-button type="button" class="mt-2" @click.native.prevent="deletePhoto" v-if="$page.user.profile_photo_path">
+                    Remove Photo
                 </jet-secondary-button>
 
                 <jet-input-error :message="form.error('photo')" class="mt-2" />

--- a/stubs/v4/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/v4/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -36,9 +36,15 @@
                     <img x-bind:src="photoPreview" class="rounded-circle" width="80px" height="80px">
                 </div>
 
-                <x-jet-secondary-button class="mt-2" type="button" x-on:click.prevent="$refs.photo.click()">
+                <x-jet-secondary-button class="mt-2 mr-2" type="button" x-on:click.prevent="$refs.photo.click()">
                     {{ __('Select A New Photo') }}
-                </x-jet-secondary-button>
+				</x-jet-secondary-button>
+				
+				@if ($this->user->profile_photo_path)
+                    <x-jet-secondary-button type="button" class="mt-2" wire:click="deleteProfilePhoto">
+                        {{ __('Remove Photo') }}
+                    </x-jet-secondary-button>
+                @endif
 
                 <x-jet-input-error for="photo" class="mt-2" />
             </div>
@@ -62,12 +68,14 @@
     </x-slot>
 
     <x-slot name="actions">
-        <x-jet-action-message class="mr-3" on="saved">
-            {{ __('Saved.') }}
-        </x-jet-action-message>
+		<div class="d-flex align-items-baseline">
+			<x-jet-action-message class="mr-3" on="saved">
+				{{ __('Saved.') }}
+			</x-jet-action-message>
 
-        <x-jet-button>
-            {{ __('Save') }}
-        </x-jet-button>
+			<x-jet-button>
+				{{ __('Save') }}
+			</x-jet-button>
+		</div>
     </x-slot>
 </x-jet-form-section>

--- a/stubs/v4/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/v4/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -28,7 +28,7 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" x-show="! photoPreview">
-                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle">
+                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle" height="80px" width="80px">
                 </div>
 
                 <!-- New Profile Photo Preview -->

--- a/stubs/v4/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/v4/livewire/resources/views/teams/team-member-manager.blade.php
@@ -29,7 +29,7 @@
                     <!-- Role -->
                     @if (count($this->roles) > 0)
                         <div class="mb-3 w-75">
-                            <x-jet-label for="role" value="Role" />
+                            <x-jet-label for="role" value="{{ __('Role') }}" />
 
                             <input type="hidden" class="{{ $errors->has('role') ? 'is-invalid' : '' }}">
                             <x-jet-input-error for="role" />

--- a/stubs/v4/livewire/resources/views/teams/update-team-name-form.blade.php
+++ b/stubs/v4/livewire/resources/views/teams/update-team-name-form.blade.php
@@ -10,7 +10,7 @@
     <x-slot name="form">
         <!-- Team Owner Information -->
         <div class="mb-4">
-            <x-jet-label value="Team Owner" />
+            <x-jet-label value="{{ __('Team Owner') }}" />
 
             <div class="d-flex mt-2">
                 <img class="rounded-circle" width="48" src="{{ $team->owner->profile_photo_url }}">
@@ -24,7 +24,7 @@
 
         <!-- Team Name -->
         <div class="w-75">
-            <x-jet-label for="name" value="Team Name" />
+            <x-jet-label for="name" value="{{ __('Team Name') }}" />
 
             <x-jet-input id="name"
                          type="text"
@@ -38,13 +38,15 @@
 
     @if (Gate::check('update', $team))
         <x-slot name="actions">
-            <x-jet-action-message class="mr-3" on="saved">
-                {{ __('Saved.') }}
-            </x-jet-action-message>
+			<div class="d-flex align-items-baseline">
+				<x-jet-action-message class="mr-3" on="saved">
+					{{ __('Saved.') }}
+				</x-jet-action-message>
 
-            <x-jet-button>
-                {{ __('Save') }}
-            </x-jet-button>
+				<x-jet-button>
+					{{ __('Save') }}
+				</x-jet-button>
+			</div>
         </x-slot>
     @endif
 </x-jet-form-section>

--- a/stubs/v4/resources/views/auth/login.blade.php
+++ b/stubs/v4/resources/views/auth/login.blade.php
@@ -43,7 +43,7 @@
                 </div>
 
                 <div class="mb-0">
-                    <div class="d-flex justify-content-end">
+                    <div class="d-flex justify-content-end align-items-baseline">
                         @if (Route::has('password.request'))
                             <a class="text-muted mr-3" href="{{ route('password.request') }}">
                                 {{ __('Forgot your password?') }}

--- a/stubs/v4/resources/views/auth/register.blade.php
+++ b/stubs/v4/resources/views/auth/register.blade.php
@@ -41,7 +41,7 @@
                 </div>
 
                 <div class="mb-0">
-                    <div class="d-flex justify-content-end">
+                    <div class="d-flex justify-content-end align-items-baseline">
                         <a class="text-muted mr-3 text-decoration-none" href="{{ route('login') }}">
                             {{ __('Already registered?') }}
                         </a>

--- a/stubs/v5/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/v5/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -28,8 +28,12 @@
                     <img :src="photoPreview" class="rounded-circle" width="80px" height="80px">
                 </div>
 
-                <jet-secondary-button class="mt-2" type="button" @click.native.prevent="selectNewPhoto">
+                <jet-secondary-button class="mt-2 mr-2" type="button" @click.native.prevent="selectNewPhoto">
                     Select A New Photo
+                </jet-secondary-button>
+
+				<jet-secondary-button type="button" class="mt-2" @click.native.prevent="deletePhoto" v-if="$page.user.profile_photo_path">
+                    Remove Photo
                 </jet-secondary-button>
 
                 <jet-input-error :message="form.error('photo')" class="mt-2" />

--- a/stubs/v5/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/v5/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -36,9 +36,15 @@
                     <img x-bind:src="photoPreview" class="rounded-circle" width="80px" height="80px">
                 </div>
 
-                <x-jet-secondary-button class="mt-2" type="button" x-on:click.prevent="$refs.photo.click()">
+                <x-jet-secondary-button class="mt-2 mr-2" type="button" x-on:click.prevent="$refs.photo.click()">
                     {{ __('Select A New Photo') }}
-                </x-jet-secondary-button>
+				</x-jet-secondary-button>
+				
+				@if ($this->user->profile_photo_path)
+                    <x-jet-secondary-button type="button" class="mt-2" wire:click="deleteProfilePhoto">
+                        {{ __('Remove Photo') }}
+                    </x-jet-secondary-button>
+                @endif
 
                 <x-jet-input-error for="photo" class="mt-2" />
             </div>
@@ -62,12 +68,14 @@
     </x-slot>
 
     <x-slot name="actions">
-        <x-jet-action-message class="mr-3" on="saved">
-            {{ __('Saved.') }}
-        </x-jet-action-message>
+		<div class="d-flex align-items-baseline">
+			<x-jet-action-message class="mr-3" on="saved">
+				{{ __('Saved.') }}
+			</x-jet-action-message>
 
-        <x-jet-button>
-            {{ __('Save') }}
-        </x-jet-button>
+			<x-jet-button>
+				{{ __('Save') }}
+			</x-jet-button>
+		</div>
     </x-slot>
 </x-jet-form-section>

--- a/stubs/v5/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/v5/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -28,7 +28,7 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" x-show="! photoPreview">
-                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle">
+                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle" height="80px" width="80px">
                 </div>
 
                 <!-- New Profile Photo Preview -->

--- a/stubs/v5/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/v5/livewire/resources/views/teams/team-member-manager.blade.php
@@ -29,7 +29,7 @@
                     <!-- Role -->
                     @if (count($this->roles) > 0)
                         <div class="mb-3 w-75">
-                            <x-jet-label for="role" value="Role" />
+                            <x-jet-label for="role" value="{{ __('Role') }}" />
 
                             <input type="hidden" class="{{ $errors->has('role') ? 'is-invalid' : '' }}">
                             <x-jet-input-error for="role" />

--- a/stubs/v5/livewire/resources/views/teams/update-team-name-form.blade.php
+++ b/stubs/v5/livewire/resources/views/teams/update-team-name-form.blade.php
@@ -10,7 +10,7 @@
     <x-slot name="form">
         <!-- Team Owner Information -->
         <div class="mb-4">
-            <x-jet-label value="Team Owner" />
+            <x-jet-label value="{{ __('Team Owner') }}" />
 
             <div class="d-flex mt-2">
                 <img class="rounded-circle" width="48" src="{{ $team->owner->profile_photo_url }}">
@@ -24,7 +24,7 @@
 
         <!-- Team Name -->
         <div class="w-75">
-            <x-jet-label for="name" value="Team Name" />
+            <x-jet-label for="name" value="{{ __('Team Name') }}" />
 
             <x-jet-input id="name"
                          type="text"
@@ -38,13 +38,15 @@
 
     @if (Gate::check('update', $team))
         <x-slot name="actions">
-            <x-jet-action-message class="mr-3" on="saved">
-                {{ __('Saved.') }}
-            </x-jet-action-message>
+			<div class="d-flex align-items-baseline">
+				<x-jet-action-message class="mr-3" on="saved">
+					{{ __('Saved.') }}
+				</x-jet-action-message>
 
-            <x-jet-button>
-                {{ __('Save') }}
-            </x-jet-button>
+				<x-jet-button>
+					{{ __('Save') }}
+				</x-jet-button>
+			</div>
         </x-slot>
     @endif
 </x-jet-form-section>

--- a/stubs/v5/resources/views/auth/login.blade.php
+++ b/stubs/v5/resources/views/auth/login.blade.php
@@ -43,7 +43,7 @@
                 </div>
 
                 <div class="mb-0">
-                    <div class="d-flex justify-content-end">
+                    <div class="d-flex justify-content-end align-items-baseline">
                         @if (Route::has('password.request'))
                             <a class="text-muted mr-3" href="{{ route('password.request') }}">
                                 {{ __('Forgot your password?') }}

--- a/stubs/v5/resources/views/auth/register.blade.php
+++ b/stubs/v5/resources/views/auth/register.blade.php
@@ -41,7 +41,7 @@
                 </div>
 
                 <div class="mb-0">
-                    <div class="d-flex justify-content-end">
+                    <div class="d-flex justify-content-end align-items-baseline">
                         <a class="text-muted mr-3 text-decoration-none" href="{{ route('login') }}">
                             {{ __('Already registered?') }}
                         </a>


### PR DESCRIPTION
…to profile in stubs/livewire.

Fix alignment in buttons login and register and fix image size of photo profile in stubs/livewire.

In login and register forms the button **Forgot your password?** and **Login** look misaligned

![login](https://user-images.githubusercontent.com/9275870/94326949-591fdd00-ff6d-11ea-8f1d-9686988b7156.png)

In this PR i add the bootstrap class `align-items-baseline` in order to fix this and looks like as Tailwind

![fix-login-aligment](https://user-images.githubusercontent.com/9275870/94326998-c92e6300-ff6d-11ea-9730-d2f89c2e7e0a.PNG)

Another fix is add the attributes `height=""` and `width=""` in the profile photo preview in the livewire stubs (in inertia stubs i found this). Otherwise photo looks as

![photo](https://user-images.githubusercontent.com/9275870/94327096-71dcc280-ff6e-11ea-8332-9b68acaf60a9.png)

I fan of Laravel and Bootstrap and I like this package!! Congratulations