### PR TITLE
Use Bootstrap pagination views

### DIFF
--- a/src/Jetstrap/JetstrapServiceProvider.php
+++ b/src/Jetstrap/JetstrapServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace NascentAfrica\Jetstrap;
 
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\ServiceProvider;
 
 class JetstrapServiceProvider extends ServiceProvider
@@ -27,6 +28,9 @@ class JetstrapServiceProvider extends ServiceProvider
     {
         $this->configurePublishing();
         $this->configureCommands();
+
+        // Use pagination views built using Bootstrap
+        Paginator::useBootstrap();
     }
 
     /**

--- a/stubs/v4/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/v4/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -1,0 +1,118 @@
+<template>
+    <span>
+        <span @click="startConfirmingPassword">
+            <slot />
+        </span>
+
+        <jet-dialog-modal id="confirmingPasswordModal" @close="confirmingPassword = false">
+            <template #title>
+                {{ title }}
+            </template>
+
+            <template #content>
+                {{ content }}
+
+                <div class="mt-4">
+                    <jet-input type="password" placeholder="Password"
+                                ref="password"
+                                v-model="form.password"
+                               :class="{ 'is-invalid': form.error }"
+                                @keyup.enter.native="confirmPassword" />
+
+                    <jet-input-error :message="form.error" />
+                </div>
+            </template>
+
+            <template #footer>
+                <jet-secondary-button data-dismiss="modal">
+                    Nevermind
+                </jet-secondary-button>
+
+                <jet-button class="ml-2" @click.native="confirmPassword" :class="{ 'text-black-50': form.processing }" :disabled="form.processing">
+                    {{ button }}
+                </jet-button>
+            </template>
+        </jet-dialog-modal>
+    </span>
+</template>
+
+<script>
+    import JetButton from './Button'
+    import JetDialogModal from './DialogModal'
+    import JetInput from './Input'
+    import JetInputError from './InputError'
+    import JetSecondaryButton from './SecondaryButton'
+
+    export default {
+        props: {
+            title: {
+                default: 'Confirm Password',
+            },
+            content: {
+                default: 'For your security, please confirm your password to continue.',
+            },
+            button: {
+                default: 'Confirm',
+            }
+        },
+
+        components: {
+            JetButton,
+            JetDialogModal,
+            JetInput,
+            JetInputError,
+            JetSecondaryButton,
+        },
+
+        data() {
+            return {
+                modal: null,
+
+                form: this.$inertia.form({
+                    password: '',
+                    error: '',
+                }, {
+                    bag: 'confirmPassword',
+                })
+            }
+        },
+
+        methods: {
+            startConfirmingPassword() {
+                this.form.error = '';
+                this.modal = new Bootstrap.Modal(document.getElementById('confirmingPasswordModal'))
+
+                axios.get('/user/confirmed-password-status').then(response => {
+                    if (response.data.confirmed) {
+                        this.$emit('confirmed');
+                    } else {
+                        this.modal.show()
+                        this.form.password = '';
+
+                        setTimeout(() => {
+                            this.$refs.password.focus()
+                        }, 250)
+                    }
+                })
+            },
+
+            confirmPassword() {
+                this.form.processing = true;
+
+                axios.post('/user/confirm-password', {
+                    password: this.form.password,
+                }).then(response => {
+                    this.modal.hide()
+                    this.form.password = '';
+                    this.form.error = '';
+                    this.form.processing = false;
+
+                    this.$nextTick(() => this.$emit('confirmed'));
+                }).catch(error => {
+                    this.form.processing = false;
+                    this.form.error = error.response.data.errors.password[0];
+                });
+            }
+        }
+    }
+</script>

--- a/stubs/v4/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/v4/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -50,35 +50,38 @@
                 </div>
             </div>
 
-            <div class="mt-3">
-                <div v-if="! twoFactorEnabled">
-                    <jet-button type="button" @click.native="enableTwoFactorAuthentication"
-                                        :class="{ 'text-black-50': enabling }"
-                                        :disabled="enabling">
-                        Enable
-                    </jet-button>
-                </div>
-
-                <div v-else>
-                    <jet-secondary-button class="mr-3"
-                                    @click.native="regenerateRecoveryCodes"
-                                    v-if="recoveryCodes.length > 0">
-                        Regenerate Recovery Codes
-                    </jet-secondary-button>
-
-                    <jet-secondary-button class="mr-3"
-                                @click.native="showRecoveryCodes"
-                                v-else>
-                        Show Recovery Codes
-                    </jet-secondary-button>
-
-                    <jet-danger-button @click.native="disableTwoFactorAuthentication"
-                                    :class="{ 'text-white-50': disabling }"
-                                    :disabled="disabling">
-                        Disable
-                    </jet-danger-button>
-                </div>
+          <div class="mt-3">
+            <div v-if="! twoFactorEnabled">
+              <jet-confirms-password @confirmed="enableTwoFactorAuthentication">
+                <jet-button type="button" :class="{ 'text-white-50': enabling }" :disabled="enabling">
+                  Enable
+                </jet-button>
+              </jet-confirms-password>
             </div>
+
+            <div v-else>
+              <jet-confirms-password @confirmed="regenerateRecoveryCodes">
+                <jet-secondary-button class="mr-3"
+                                      v-if="recoveryCodes.length > 0">
+                  Regenerate Recovery Codes
+                </jet-secondary-button>
+              </jet-confirms-password>
+
+              <jet-confirms-password @confirmed="showRecoveryCodes">
+                <jet-secondary-button class="mr-3" v-if="recoveryCodes.length == 0">
+                  Show Recovery Codes
+                </jet-secondary-button>
+              </jet-confirms-password>
+
+              <jet-confirms-password @confirmed="disableTwoFactorAuthentication">
+                <jet-danger-button
+                    :class="{ 'text-white-50': disabling }"
+                    :disabled="disabling">
+                  Disable
+                </jet-danger-button>
+              </jet-confirms-password>
+            </div>
+          </div>
         </template>
     </jet-action-section>
 </template>
@@ -86,6 +89,7 @@
 <script>
     import JetActionSection from './../../Jetstream/ActionSection'
     import JetButton from './../../Jetstream/Button'
+    import JetConfirmsPassword from './../../Jetstream/ConfirmsPassword'
     import JetDangerButton from './../../Jetstream/DangerButton'
     import JetSecondaryButton from './../../Jetstream/SecondaryButton'
 
@@ -93,6 +97,7 @@
         components: {
             JetActionSection,
             JetButton,
+            JetConfirmsPassword,
             JetDangerButton,
             JetSecondaryButton,
         },

--- a/stubs/v5/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/v5/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -1,0 +1,118 @@
+<template>
+    <span>
+        <span @click="startConfirmingPassword">
+            <slot />
+        </span>
+
+        <jet-dialog-modal id="confirmingPasswordModal" @close="confirmingPassword = false">
+            <template #title>
+                {{ title }}
+            </template>
+
+            <template #content>
+                {{ content }}
+
+                <div class="mt-4">
+                    <jet-input type="password" placeholder="Password"
+                                ref="password"
+                                v-model="form.password"
+                               :class="{ 'is-invalid': form.error }"
+                                @keyup.enter.native="confirmPassword" />
+
+                    <jet-input-error :message="form.error" />
+                </div>
+            </template>
+
+            <template #footer>
+                <jet-secondary-button data-dismiss="modal">
+                    Nevermind
+                </jet-secondary-button>
+
+                <jet-button class="ml-2" @click.native="confirmPassword" :class="{ 'text-black-50': form.processing }" :disabled="form.processing">
+                    {{ button }}
+                </jet-button>
+            </template>
+        </jet-dialog-modal>
+    </span>
+</template>
+
+<script>
+    import JetButton from './Button'
+    import JetDialogModal from './DialogModal'
+    import JetInput from './Input'
+    import JetInputError from './InputError'
+    import JetSecondaryButton from './SecondaryButton'
+
+    export default {
+        props: {
+            title: {
+                default: 'Confirm Password',
+            },
+            content: {
+                default: 'For your security, please confirm your password to continue.',
+            },
+            button: {
+                default: 'Confirm',
+            }
+        },
+
+        components: {
+            JetButton,
+            JetDialogModal,
+            JetInput,
+            JetInputError,
+            JetSecondaryButton,
+        },
+
+        data() {
+            return {
+                modal: null,
+
+                form: this.$inertia.form({
+                    password: '',
+                    error: '',
+                }, {
+                    bag: 'confirmPassword',
+                })
+            }
+        },
+
+        methods: {
+            startConfirmingPassword() {
+                this.form.error = '';
+                this.modal = new Bootstrap.Modal(document.getElementById('confirmingPasswordModal'))
+
+                axios.get('/user/confirmed-password-status').then(response => {
+                    if (response.data.confirmed) {
+                        this.$emit('confirmed');
+                    } else {
+                        this.modal.show()
+                        this.form.password = '';
+
+                        setTimeout(() => {
+                            this.$refs.password.focus()
+                        }, 250)
+                    }
+                })
+            },
+
+            confirmPassword() {
+                this.form.processing = true;
+
+                axios.post('/user/confirm-password', {
+                    password: this.form.password,
+                }).then(response => {
+                    this.modal.hide()
+                    this.form.password = '';
+                    this.form.error = '';
+                    this.form.processing = false;
+
+                    this.$nextTick(() => this.$emit('confirmed'));
+                }).catch(error => {
+                    this.form.processing = false;
+                    this.form.error = error.response.data.errors.password[0];
+                });
+            }
+        }
+    }
+</script>

--- a/stubs/v5/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/v5/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -50,35 +50,38 @@
                 </div>
             </div>
 
-            <div class="mt-3">
-                <div v-if="! twoFactorEnabled">
-                    <jet-button type="button" @click.native="enableTwoFactorAuthentication"
-                                        :class="{ 'text-black-50': enabling }"
-                                        :disabled="enabling">
-                        Enable
-                    </jet-button>
-                </div>
-
-                <div v-else>
-                    <jet-secondary-button class="mr-3"
-                                    @click.native="regenerateRecoveryCodes"
-                                    v-if="recoveryCodes.length > 0">
-                        Regenerate Recovery Codes
-                    </jet-secondary-button>
-
-                    <jet-secondary-button class="mr-3"
-                                @click.native="showRecoveryCodes"
-                                v-else>
-                        Show Recovery Codes
-                    </jet-secondary-button>
-
-                    <jet-danger-button @click.native="disableTwoFactorAuthentication"
-                                    :class="{ 'text-white-50': disabling }"
-                                    :disabled="disabling">
-                        Disable
-                    </jet-danger-button>
-                </div>
+          <div class="mt-3">
+            <div v-if="! twoFactorEnabled">
+              <jet-confirms-password @confirmed="enableTwoFactorAuthentication">
+                <jet-button type="button" :class="{ 'text-white-50': enabling }" :disabled="enabling">
+                  Enable
+                </jet-button>
+              </jet-confirms-password>
             </div>
+
+            <div v-else>
+              <jet-confirms-password @confirmed="regenerateRecoveryCodes">
+                <jet-secondary-button class="mr-3"
+                                      v-if="recoveryCodes.length > 0">
+                  Regenerate Recovery Codes
+                </jet-secondary-button>
+              </jet-confirms-password>
+
+              <jet-confirms-password @confirmed="showRecoveryCodes">
+                <jet-secondary-button class="mr-3" v-if="recoveryCodes.length == 0">
+                  Show Recovery Codes
+                </jet-secondary-button>
+              </jet-confirms-password>
+
+              <jet-confirms-password @confirmed="disableTwoFactorAuthentication">
+                <jet-danger-button
+                    :class="{ 'text-white-50': disabling }"
+                    :disabled="disabling">
+                  Disable
+                </jet-danger-button>
+              </jet-confirms-password>
+            </div>
+          </div>
         </template>
     </jet-action-section>
 </template>
@@ -86,6 +89,7 @@
 <script>
     import JetActionSection from './../../Jetstream/ActionSection'
     import JetButton from './../../Jetstream/Button'
+    import JetConfirmsPassword from './../../Jetstream/ConfirmsPassword'
     import JetDangerButton from './../../Jetstream/DangerButton'
     import JetSecondaryButton from './../../Jetstream/SecondaryButton'
 
@@ -93,6 +97,7 @@
         components: {
             JetActionSection,
             JetButton,
+            JetConfirmsPassword,
             JetDangerButton,
             JetSecondaryButton,
         },


### PR DESCRIPTION
From version 8, Laravel use [Tailwind CSS](https://tailwindcss.com/) by default in the [pagination views](https://laravel.com/docs/8.x/pagination#introduction). However [Laravel also allows the user to use Bootstrap's predefined pagination](https://laravel.com/docs/8.x/pagination#using-bootstrap) calling the paginator's `useBootstrap` method within a **Service Provider**.

If a user installs this package it should be because he wants to use Bootstrap, therefore we should include this configuration in our **Service Provider** so that he does not have to do it manually.

What do you think @tsommie?