### PR TITLE
[v2.x] Align profile thumbnail dropdown with Teams dropdown

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -21,7 +21,7 @@
           </ul>
 
           <!-- Right Side Of Navbar -->
-          <ul class="navbar-nav ml-auto">
+          <ul class="navbar-nav ml-auto align-items-baseline">
             <!-- Team Management -->
             <jet-dropdown id="teamManagementDropdown" v-if="$page.props.jetstream.hasTeamFeatures">
               <template #trigger>

--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -17,7 +17,7 @@
             </ul>
 
             <!-- Right Side Of Navbar -->
-            <ul class="navbar-nav ml-auto">
+            <ul class="navbar-nav ml-auto align-items-baseline">
                 <!-- Teams Dropdown -->
                 @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
                     <x-jet-dropdown id="teamManagementDropdown">


### PR DESCRIPTION
When `Features::profilePhotos()` is enabled in `jetstream.php` we can watch that the dropdown of teams and the dropdown of profile photo look disaligned

![Jetstrap2fix](https://user-images.githubusercontent.com/9275870/104521593-273d8f80-55cb-11eb-840e-88472716eb78.PNG)

