### PR TITLE
[v2.x] Separate 'Login' and 'Logout' in 'Log in' and 'Log Out'

### DIFF
--- a/breeze/inertia/resources/js/Pages/Auth/Login.vue
+++ b/breeze/inertia/resources/js/Pages/Auth/Login.vue
@@ -35,7 +35,7 @@
           </inertia-link>
 
           <breeze-button class="ml-4" :class="{ 'text-white-50': form.processing }" :disabled="form.processing">
-            Login
+            Log in
           </breeze-button>
         </div>
       </div>

--- a/breeze/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/breeze/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -15,7 +15,7 @@
           Resend Verification Email
         </breeze-button>
 
-        <inertia-link :href="route('logout')" method="post" as="button" class="btn btn-link">Logout</inertia-link>
+        <inertia-link :href="route('logout')" method="post" as="button" class="btn btn-link">Log out</inertia-link>
       </div>
     </form>
   </div>

--- a/breeze/inertia/resources/js/Pages/Welcome.vue
+++ b/breeze/inertia/resources/js/Pages/Welcome.vue
@@ -10,7 +10,7 @@
 
             <template v-else>
               <inertia-link :href="route('login')" class="text-muted">
-                Login
+                Log in
               </inertia-link>
 
               <inertia-link v-if="canRegister" :href="route('register')" class="ml-4 text-muted">

--- a/breeze/resources/views/auth/login.blade.php
+++ b/breeze/resources/views/auth/login.blade.php
@@ -52,7 +52,7 @@
                         @endif
 
                         <x-button>
-                            {{ __('Login') }}
+                            {{ __('Log in') }}
                         </x-button>
                     </div>
                 </div>

--- a/breeze/resources/views/auth/verify-email.blade.php
+++ b/breeze/resources/views/auth/verify-email.blade.php
@@ -32,7 +32,7 @@
                     @csrf
 
                     <button type="submit" class="btn btn-link">
-                        {{ __('Logout') }}
+                        {{ __('Log Out') }}
                     </button>
                 </form>
             </div>

--- a/breeze/resources/views/layouts/navigation.blade.php
+++ b/breeze/resources/views/layouts/navigation.blade.php
@@ -34,7 +34,7 @@
                                 <x-dropdown-link :href="route('logout')"
                                                  onclick="event.preventDefault();
                                                 this.closest('form').submit();">
-                                    {{ __('Logout') }}
+                                    {{ __('Log Out') }}
                                 </x-dropdown-link>
                             </form>
                         </x-slot>

--- a/presets/AdminLte/breeze/inertia/resources/js/Layouts/Authenticated.vue
+++ b/presets/AdminLte/breeze/inertia/resources/js/Layouts/Authenticated.vue
@@ -26,7 +26,7 @@
           <template #content>
             <!-- Authentication -->
             <breeze-dropdown-link :href="route('logout')" method="post">
-              Logout
+              Log Out
             </breeze-dropdown-link>
           </template>
         </breeze-dropdown>

--- a/presets/AdminLte/breeze/resources/views/layouts/navigation.blade.php
+++ b/presets/AdminLte/breeze/resources/views/layouts/navigation.blade.php
@@ -31,7 +31,7 @@
                         <x-dropdown-link href="{{ route('logout') }}"
                                          onclick="event.preventDefault();
                                                              document.getElementById('logout-form').submit();">
-                            {{ __('Logout') }}
+                            {{ __('Log Out') }}
                         </x-dropdown-link>
                     </form>
                 </x-slot>

--- a/presets/AdminLte/inertia/resources/js/Layouts/AppLayout.vue
+++ b/presets/AdminLte/inertia/resources/js/Layouts/AppLayout.vue
@@ -93,7 +93,7 @@
             <!-- Authentication -->
             <form @submit.prevent="logout">
               <jet-dropdown-link as="button">
-                Logout
+                Log Out
               </jet-dropdown-link>
             </form>
           </template>

--- a/presets/AdminLte/resources/views/navigation-menu.blade.php
+++ b/presets/AdminLte/resources/views/navigation-menu.blade.php
@@ -91,7 +91,7 @@
                     <x-jet-dropdown-link href="{{ route('logout') }}"
                                          onclick="event.preventDefault();
                                                              document.getElementById('logout-form').submit();">
-                        {{ __('Logout') }}
+                        {{ __('Log Out') }}
                     </x-jet-dropdown-link>
                     <form method="POST" id="logout-form" action="{{ route('logout') }}">
                         @csrf

--- a/presets/CoreUi/breeze/inertia/resources/js/Layouts/Authenticated.vue
+++ b/presets/CoreUi/breeze/inertia/resources/js/Layouts/Authenticated.vue
@@ -45,7 +45,7 @@
           <template #content>
             <!-- Authentication -->
             <breeze-dropdown-link :href="route('logout')" method="post">
-              Logout
+              Log Out
             </breeze-dropdown-link>
           </template>
         </breeze-dropdown>

--- a/presets/CoreUi/breeze/resources/views/layouts/navigation.blade.php
+++ b/presets/CoreUi/breeze/resources/views/layouts/navigation.blade.php
@@ -22,7 +22,7 @@
                 <x-dropdown-link href="{{ route('logout') }}"
                                  onclick="event.preventDefault();
                                                 document.getElementById('logout-form').submit();">
-                    {{ __('Logout') }}
+                    {{ __('Log Out') }}
                 </x-dropdown-link>
             </x-slot>
         </x-dropdown>

--- a/presets/CoreUi/inertia/resources/js/Layouts/AppLayout.vue
+++ b/presets/CoreUi/inertia/resources/js/Layouts/AppLayout.vue
@@ -110,7 +110,7 @@
               <!-- Authentication -->
               <form @submit.prevent="logout">
                 <jet-dropdown-link as="button">
-                  Logout
+                  Log out
                 </jet-dropdown-link>
               </form>
             </template>

--- a/presets/CoreUi/resources/views/navigation-menu.blade.php
+++ b/presets/CoreUi/resources/views/navigation-menu.blade.php
@@ -79,7 +79,7 @@
                 <x-jet-dropdown-link href="{{ route('logout') }}"
                                      onclick="event.preventDefault();
                                  document.getElementById('logout-form').submit();">
-                    {{ __('Logout') }}
+                    {{ __('Log Out') }}
                 </x-jet-dropdown-link>
                 <form method="POST" id="logout-form" action="{{ route('logout') }}">
                     @csrf

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -40,7 +40,7 @@
             </inertia-link>
 
             <jet-button class="ml-4" :class="{ 'text-white-50': form.processing }" :disabled="form.processing">
-              Login
+              Log in
             </jet-button>
           </div>
         </div>

--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -19,7 +19,7 @@
             Resend Verification Email
           </jet-button>
 
-          <inertia-link :href="route('logout')" method="post" as="button" class="btn btn-link">Logout</inertia-link>
+          <inertia-link :href="route('logout')" method="post" as="button" class="btn btn-link">Log out</inertia-link>
         </div>
       </form>
     </div>

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -5,7 +5,7 @@
     </template>
 
     <template #description>
-      Manage and logout your active sessions on other browsers and devices.
+      Manage and log out your active sessions on other browsers and devices.
     </template>
 
     <template #content>
@@ -15,7 +15,7 @@
       </jet-action-message>
 
       <div>
-        If necessary, you may logout of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.
+        If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.
       </div>
 
       <!-- Other Browser Sessions -->
@@ -54,14 +54,14 @@
         </jet-button>
       </div>
 
-      <!-- Logout Other Devices Confirmation Modal -->
+      <!-- Log out Other Devices Confirmation Modal -->
       <jet-dialog-modal id="confirmingLogoutModal">
         <template #title>
           Log out Other Browser Sessions
         </template>
 
         <template #content>
-          Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.
+          Please enter your password to confirm you would like to log out of your other browser sessions across all of your devices.
 
           <div class="form-group mt-3 w-md-75">
             <jet-input type="password" placeholder="Password"

--- a/stubs/inertia/resources/js/Pages/Welcome.vue
+++ b/stubs/inertia/resources/js/Pages/Welcome.vue
@@ -10,7 +10,7 @@
 
             <template v-else>
               <inertia-link :href="route('login')" class="text-muted">
-                Login
+                Log in
               </inertia-link>
 
               <inertia-link v-if="canRegister" :href="route('register')" class="ml-4 text-muted">

--- a/stubs/livewire/resources/views/auth/login.blade.php
+++ b/stubs/livewire/resources/views/auth/login.blade.php
@@ -50,7 +50,7 @@
                         @endif
 
                         <x-jet-button>
-                            {{ __('Login') }}
+                            {{ __('Log in') }}
                         </x-jet-button>
                     </div>
                 </div>

--- a/stubs/livewire/resources/views/auth/verify-email.blade.php
+++ b/stubs/livewire/resources/views/auth/verify-email.blade.php
@@ -30,7 +30,7 @@
                     @csrf
 
                     <button type="submit" class="btn btn-link">
-                        {{ __('Logout') }}
+                        {{ __('Log Out') }}
                     </button>
                 </form>
             </div>

--- a/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
+++ b/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
@@ -4,7 +4,7 @@
     </x-slot>
 
     <x-slot name="description">
-        {{ __('Manage and logout your active sessions on other browsers and devices.') }}
+        {{ __('Manage and log out your active sessions on other browsers and devices.') }}
     </x-slot>
 
     <x-slot name="content">
@@ -13,7 +13,7 @@
         </x-jet-action-message>
 
         <div>
-            {{ __('If necessary, you may logout of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.') }}
+            {{ __('If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.') }}
         </div>
 
         @if (count($this->sessions) > 0)
@@ -57,18 +57,18 @@
 
         <div class="d-flex mt-3">
             <x-jet-button wire:click="confirmLogout" wire:loading.attr="disabled">
-                {{ __('Logout Other Browser Sessions') }}
+                {{ __('Log Out Other Browser Sessions') }}
             </x-jet-button>
         </div>
 
-        <!-- Logout Other Devices Confirmation Modal -->
+        <!-- Log out Other Devices Confirmation Modal -->
         <x-jet-dialog-modal wire:model="confirmingLogout">
             <x-slot name="title">
-                {{ __('Logout Other Browser Sessions') }}
+                {{ __('Log Out Other Browser Sessions') }}
             </x-slot>
 
             <x-slot name="content">
-                {{ __('Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.') }}
+                {{ __('Please enter your password to confirm you would like to log out of your other browser sessions across all of your devices.') }}
 
                 <div class="mt-3 w-md-75" x-data="{}" x-on:confirming-logout-other-browser-sessions.window="setTimeout(() => $refs.password.focus(), 250)">
                     <x-jet-input type="password" placeholder="{{ __('Password') }}"

--- a/stubs/resources/views/welcome.blade.php
+++ b/stubs/resources/views/welcome.blade.php
@@ -29,7 +29,7 @@
                         @auth
                             <a href="{{ url('/dashboard') }}" class="text-muted">Dashboard</a>
                         @else
-                            <a href="{{ route('login') }}" class="text-muted">Login</a>
+                            <a href="{{ route('login') }}" class="text-muted">Log in</a>
 
                             @if (Route::has('register'))
                                 <a href="{{ route('register') }}" class="ml-4 text-muted">Register</a>


### PR DESCRIPTION
In the last versions of [Laravel Jetstream](https://github.com/laravel/jetstream/commit/e85dc61adb78c2c63a9ac6e174adaaafa9003d8d), [Laravel Breeze](https://github.com/laravel/breeze/commit/0b93f870eff446621fa84f3c46d567cfbd127d9f) and [Laravel/laravel](https://github.com/laravel/laravel/commit/9a56a60cc9e3785683e256d511ee1fb533025a0a) have been changed the words *Login* and *Logout* by *Log in* and *Log out*.