### PR TITLE
[v2.x] Fix 'remember me' checkbox label for

### DIFF
--- a/breeze/resources/views/auth/login.blade.php
+++ b/breeze/resources/views/auth/login.blade.php
@@ -37,7 +37,7 @@
                     <div class="form-check">
                         <x-checkbox id="remember_me" name="remember" />
 
-                        <label class="form-check-label" for="remember">
+                        <label class="form-check-label" for="remember_me">
                             {{ __('Remember Me') }}
                         </label>
                     </div>


### PR DESCRIPTION
In view `auth/login.blade.php` the checkbox remember id mismatch with label for. Therefore it was impossible to check by clicking on the label 