### PR TITLE
Fix Bootstrap is not defined on 2FA modal

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -82,13 +82,13 @@
     methods: {
       startConfirmingPassword() {
         this.form.error = '';
-        this.modal = new Bootstrap.Modal(document.getElementById('confirmingPasswordModal'))
+        this.modal = $('#confirmingPasswordModal');
 
         axios.get(route('password.confirmation')).then(response => {
           if (response.data.confirmed) {
             this.$emit('confirmed');
           } else {
-            this.modal.show()
+            this.modal.modal('toggle');
             this.form.password = '';
 
             setTimeout(() => {
@@ -104,7 +104,7 @@
         axios.post(route('password.confirm'), {
           password: this.form.password,
         }).then(response => {
-          this.modal.hide()
+          this.modal.modal('hide');
           this.form.password = '';
           this.form.error = '';
           this.form.processing = false;

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -68,7 +68,7 @@
 
     data() {
       return {
-        modal: null,
+        bootstrap: null,
 
         form: this.$inertia.form({
           password: '',
@@ -82,13 +82,13 @@
     methods: {
       startConfirmingPassword() {
         this.form.error = '';
-        this.modal = $('#confirmingPasswordModal');
+        this.bootstrap = $('#confirmingPasswordModal');
 
         axios.get(route('password.confirmation')).then(response => {
           if (response.data.confirmed) {
             this.$emit('confirmed');
           } else {
-            this.modal.modal('toggle');
+            this.bootstrap.modal('toggle');
             this.form.password = '';
 
             setTimeout(() => {
@@ -104,7 +104,7 @@
         axios.post(route('password.confirm'), {
           password: this.form.password,
         }).then(response => {
-          this.modal.modal('hide');
+          this.bootstrap.modal('hide');
           this.form.password = '';
           this.form.error = '';
           this.form.processing = false;


### PR DESCRIPTION
Not sure if it was just me, but on a fresh install of jetstream 2.2.5 with inertia stack and teams active.

Enabling two factor authentication after performing the jetstrap swap resulted in the following error and the modal in ConfirmsPassword.vue fails to load.

<img width="716" alt="Screenshot 2021-03-28 at 13 45 27" src="https://user-images.githubusercontent.com/10721000/112748528-31b5d580-8fcd-11eb-81e6-b72344505d7f.png">

This is what I did to get it to work.

Thanks for the great project! 
