### PR TITLE
Fix base Vue Modal component not using actual bootstrap class

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -1,7 +1,7 @@
 <template>
   <teleport to="body">
     <div class="modal fade" tabindex="-1" :id="id" :aria-labelledby="id" aria-hidden="true">
-      <div class="modal-dialog" :class="maxWidth">
+      <div class="modal-dialog" :class="maxWidthClass">
         <slot></slot>
       </div>
     </div>


### PR DESCRIPTION
Just a small issue I found when creating a modal with Jetstream/Intertia stack. The Modals (DialogModal.vue and others) created were not being sized according to the supplied prop 'maxWidth'. 

As it turns out the base Modal.vue computes the corresponding Bootstrap class from the prop maxWidth. 

We simply just need to use the computed Bootstrap class and the modals are sized correctly as required.