### PR TITLE
Fix close from outside click

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -42,7 +42,7 @@ switch ($maxWidth ?? '') {
             show = false
         })
     }"
-    wire:ignore.self 
+
     class="modal fade" 
     tabindex="-1" 
     id="{{ $id }}" 

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -41,8 +41,15 @@ switch ($maxWidth ?? '') {
         modal.on('hide.bs.modal', function () {
             show = false
         })
+        
+        modal.click(function(e) {
+            if (e.target == this) {
+                show = false;
+            }
+        });
     }"
-
+    x-on:keydown.escape.window="show = false"
+    wire:ignore.self
     class="modal fade" 
     tabindex="-1" 
     id="{{ $id }}" 


### PR DESCRIPTION
When click outside the modal or use the X button close of modal title the modal dosen't show anymore.