### PR TITLE
Fix Modal close and tab acces

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -27,12 +27,26 @@ switch ($maxWidth ?? '') {
 <div 
     x-data="{
         show: @entangle($attributes->wire('model')).defer,
+        focusables() {
+            // All focusable element types...
+            let selector = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
+            return [...$el.querySelectorAll(selector)]
+                // All non-disabled elements...
+                .filter(el => ! el.hasAttribute('disabled'))
+        },
+        firstFocusable() { return this.focusables()[0] },
+        lastFocusable() { return this.focusables().slice(-1)[0] },
+        nextFocusable() { return this.focusables()[this.nextFocusableIndex()] || this.firstFocusable() },
+        prevFocusable() { return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable() },
+        nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
+        prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) -1 },
     }"
     x-init="() => {
         let modal = $('#{{ $id }}');
         $watch('show', value => {
             if (value) {
                 modal.modal('show')
+                setTimeout(() => (focusables()[0]).focus(), 250);
             } else {
                 modal.modal('hide')
             }
@@ -41,10 +55,18 @@ switch ($maxWidth ?? '') {
         modal.on('hide.bs.modal', function () {
             show = false
         })
+        
+        modal.click(function(e) {
+            if (e.target == this) {
+                show = false;
+            }
+        });
     }"
+    x-on:keydown.escape.window="show = false"
+    x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
+    x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     wire:ignore.self 
     class="modal fade" 
-    tabindex="-1" 
     id="{{ $id }}" 
     aria-labelledby="{{ $id }}" 
     aria-hidden="true"


### PR DESCRIPTION
The tab acces support come from original jetstream implementation

You can switch between the element with the tab

The javascript code:
modal.click(function(e) {
    if (e.target == this) {
        show = false;
    }
});
close the modal correctly when you click outside. Now you can reopen it without issue.

The javascript code:
setTimeout(() => (focusables()[0]).focus(), 250);
set the focus on first element of the modal. Usefull if you have form and you whant focus on it.

x-on:keydown.escape.window="show = false"
close the modal with the esc key (from jetstream implementation)