### PR TITLE
Fix logout dropdown link and add missing Head in Welcome for breeze

### DIFF
--- a/breeze/inertia/resources/js/Layouts/Authenticated.vue
+++ b/breeze/inertia/resources/js/Layouts/Authenticated.vue
@@ -34,7 +34,7 @@
 
               <template #content>
                 <!-- Authentication -->
-                <breeze-dropdown-link :href="route('logout')" method="post">
+                <breeze-dropdown-link :href="route('logout')" method="post" as="button">
                   Log Out
                 </breeze-dropdown-link>
               </template>

--- a/breeze/inertia/resources/js/Layouts/Authenticated.vue
+++ b/breeze/inertia/resources/js/Layouts/Authenticated.vue
@@ -34,7 +34,7 @@
 
               <template #content>
                 <!-- Authentication -->
-                <breeze-dropdown-link @click="logout" :as="'button'">
+                <breeze-dropdown-link @click="logout" as="button">
                   Log Out
                 </breeze-dropdown-link>
               </template>

--- a/breeze/inertia/resources/js/Layouts/Authenticated.vue
+++ b/breeze/inertia/resources/js/Layouts/Authenticated.vue
@@ -34,7 +34,7 @@
 
               <template #content>
                 <!-- Authentication -->
-                <breeze-dropdown-link :href="route('logout')" method="post" as="button">
+                <breeze-dropdown-link @click="logout" :as="'button'">
                   Log Out
                 </breeze-dropdown-link>
               </template>
@@ -77,6 +77,12 @@ export default {
   data() {
     return {
       showingNavigationDropdown: false,
+    }
+  },
+
+  methods: {
+    logout() {
+      Inertia.post(route("logout"));
     }
   },
 }

--- a/breeze/inertia/resources/js/Pages/Welcome.vue
+++ b/breeze/inertia/resources/js/Pages/Welcome.vue
@@ -301,10 +301,11 @@
 </template>
 
 <script>
-import { Link } from "@inertiajs/inertia-vue3";
+import { Head, Link } from "@inertiajs/inertia-vue3";
 
 export default {
   components: {
+    Head,
     Link
   },
   props: {


### PR DESCRIPTION
Logout dropdown link
- Used the button instead of a
- \<a\> causes "Open Link in New Tab/Window" accessibility issues when used with POST.
- This is generating warnings in the browser console.

Missing Head in Welcome
- Simply added the missing Head component import in the Welcome Page component for Breeze