### PR TITLE
Bug fixed for logout() in Authenticated.vue

### DIFF
--- a/breeze/inertia/resources/js/Layouts/Authenticated.vue
+++ b/breeze/inertia/resources/js/Layouts/Authenticated.vue
@@ -64,6 +64,7 @@ import BreezeDropdown from '@/Components/Dropdown.vue'
 import BreezeDropdownLink from '@/Components/DropdownLink.vue'
 import BreezeNavLink from '@/Components/NavLink.vue'
 import { Link } from '@inertiajs/inertia-vue3'
+import { Inertia } from '@inertiajs/inertia'
 
 export default {
   components: {


### PR DESCRIPTION
{ Inertia } needed to be imported before using in the logout() function

This was the console error I was getting upon clicking the logout.
![inertia-bug-in-nascent-africa](https://user-images.githubusercontent.com/45780006/161606539-5c859a92-c8c0-4db8-9c7d-46336a3ea0f9.jpg)
