### PR TITLE
Remove units from img element dimensions

### DIFF
--- a/presets/Common/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/presets/Common/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -29,7 +29,7 @@
 
         <!-- New Profile Photo Preview -->
         <div class="mt-2" v-show="photoPreview">
-          <img :src="photoPreview" class="rounded-circle" width="80px" height="80px">
+          <img :src="photoPreview" class="rounded-circle" width="80" height="80">
         </div>
 
         <jet-secondary-button class="mt-2 me-2" type="button" @click.prevent="selectNewPhoto">

--- a/presets/Common/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/presets/Common/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -33,12 +33,12 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" x-show="! photoPreview">
-                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle" height="80px" width="80px">
+                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle" height="80" width="80">
                 </div>
 
                 <!-- New Profile Photo Preview -->
                 <div class="mt-2" x-show="photoPreview">
-                    <img x-bind:src="photoPreview" class="rounded-circle" width="80px" height="80px">
+                    <img x-bind:src="photoPreview" class="rounded-circle" width="80" height="80">
                 </div>
 
                 <x-jet-secondary-button class="mt-2 me-2" type="button" x-on:click.prevent="$refs.photo.click()">

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -29,7 +29,7 @@
 
         <!-- New Profile Photo Preview -->
         <div class="mt-2" v-show="photoPreview">
-          <img :src="photoPreview" class="rounded-circle" width="80px" height="80px">
+          <img :src="photoPreview" class="rounded-circle" width="80" height="80">
         </div>
 
         <jet-secondary-button class="mt-2 me-2" type="button" @click.prevent="selectNewPhoto">

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -33,12 +33,12 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" x-show="! photoPreview">
-                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle" height="80px" width="80px">
+                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-circle" height="80" width="80">
                 </div>
 
                 <!-- New Profile Photo Preview -->
                 <div class="mt-2" x-show="photoPreview">
-                    <img x-bind:src="photoPreview" class="rounded-circle" width="80px" height="80px">
+                    <img x-bind:src="photoPreview" class="rounded-circle" width="80" height="80">
                 </div>
 
                 <x-jet-secondary-button class="mt-2 me-2" type="button" x-on:click.prevent="$refs.photo.click()">


### PR DESCRIPTION
Img element `width` and `height` attributes should be numeric:
https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element